### PR TITLE
Fixed build failure on kernels 3.7.1 through to 3.9.9

### DIFF
--- a/linux/vr_genetlink.c
+++ b/linux/vr_genetlink.c
@@ -112,7 +112,7 @@ netlink_trans_request(struct sk_buff *in_skb, struct genl_info *info)
         len = response->vr_message_len;
         len += GENL_HDRLEN + NLA_HDRLEN;
         len = NLMSG_ALIGN(len);
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,9,10))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0))
         netlink_id =  NETLINK_CB(in_skb).pid;
 #else
         netlink_id =  NETLINK_CB(in_skb).portid;


### PR DESCRIPTION
Updated check to kernel version from 3.9.10 to 3.7.0 to represent actual time netlink_skb_parms.pid changed to netlink_skb_parms.portid (15e473046cb6e5d18a4d0057e61d76315230382b)
