### PR TITLE
- After adding tunnel headers, but before segmentation, packet length ca...

### DIFF
--- a/dp-core/vr_nexthop.c
+++ b/dp-core/vr_nexthop.c
@@ -814,6 +814,8 @@ nh_udp_tunnel(unsigned short vrf, struct vr_packet *pkt,
         goto send_fail;
     }
 
+    if (pkt_len(pkt) > ((1 << sizeof(ip->ip_len) * 8)))
+        goto send_fail;
     /* 
      * Incase of mirroring set the inner network header to the newly added 
      * header so that this is fragmented and checksummed

--- a/include/vr_packet.h
+++ b/include/vr_packet.h
@@ -577,7 +577,7 @@ pkt_head_len(struct vr_packet *pkt)
     return pkt->vp_len;
 }
 
-static inline unsigned short
+static inline unsigned int
 pkt_len(struct vr_packet *pkt)
 {
     return pkt_head_len(pkt) + vr_pfrag_len(pkt);


### PR DESCRIPTION
...n be

more than 65535. So, pkt_len() should return an integer rather than a short.
Once segmentation happens, we anyway update the outer ip header length. So,
whatever is updated in between (during the course of ip header addition),
really doesn't matter.
- Mirror bug: If the mirrored packet is TCP and is marked for GSO, we carry
  that gso type to mirror packet which is in-fact a UDP packet. So, correct the
  gso type, if the type is not what is expected for UDP packets
