### PR TITLE
While doing RPF check for ECMP nh, source ip/intf is compared against al...

### DIFF
--- a/dp-core/vr_nexthop.c
+++ b/dp-core/vr_nexthop.c
@@ -309,7 +309,7 @@ nh_composite_ecmp_validate_src(unsigned short vrf, struct vr_packet *pkt,
             if (i == fmd->fmd_ecmp_src_nh_index)
                 continue;
 
-            cnh = nh->nh_component_nh[fmd->fmd_ecmp_src_nh_index].cnh;
+            cnh = nh->nh_component_nh[i].cnh;
             if (!cnh || !cnh->nh_validate_src)
                 continue;
 


### PR DESCRIPTION
...l

component NH, to check if they are valid source. If valid and the source
is different then packet is trapped to agent, to mark forward flow to goto
new source. Correcting component NH index to picked up for validation.
