### PR TITLE
[Double commit]

### DIFF
--- a/linux/vr_host_interface.c
+++ b/linux/vr_host_interface.c
@@ -712,9 +712,6 @@ linux_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
                 cksum_off = offsetof(struct vr_udp, udp_csum);
 
             skb_partial_csum_set(skb, (transport_off - skb_headroom(skb)), cksum_off);
-        } else {
-            skb->ip_summed = CHECKSUM_NONE;
-            skb->csum = 0;
         }
 
         /*


### PR DESCRIPTION
-Should not touch checksum type and value, if it is really not required.
One side effect was that we were overwriting the field indicating that
checksum is unnecessary.

For mpls over udp, we calculate checksum of the entire packet and store it in
udp header. In the receiving end, we will verify the outer checksum, and mark
the packet as one where calculation of checksum is unnecessary, indicating to
the vm that it should not calculate checksum of the inner packet (since inner
packet checksum was not calculated even at the sending end). Once the type was
overwritten, packets were dropped in vm.
