### PR TITLE
- If the packet has to go to agent and needs to be held in the flow entr...

### DIFF
--- a/dp-core/vr_mpls.c
+++ b/dp-core/vr_mpls.c
@@ -8,15 +8,21 @@
 #include "vr_sandesh.h"
 #include "vr_mpls.h"
 
+struct vr_nexthop *
+__vrouter_get_label(struct vrouter *router, unsigned int label)
+{
+    if (!router || label > router->vr_max_labels)
+        return NULL;
+
+    return router->vr_ilm[label];
+}
+
 static struct vr_nexthop *
 vrouter_get_label(unsigned int rid, unsigned int label)
 {
     struct vrouter *router = vrouter_get(rid);
 
-    if (!router || label > router->vr_max_labels)
-        return NULL;
-
-    return router->vr_ilm[label];
+    return __vrouter_get_label(router, label);
 }
 
 int
@@ -258,6 +264,7 @@ vr_mpls_input(struct vrouter *router, struct vr_packet *pkt,
 
     ip = (struct vr_ip *)pkt_network_header(pkt);
     fmd->fmd_outer_src_ip = ip->ip_saddr;
+    fmd->fmd_label = label;
 
     /* Store the TTL in packet. Will be used for multicast replication */
     pkt->vp_ttl = ttl;

--- a/include/vr_interface.h
+++ b/include/vr_interface.h
@@ -20,8 +20,12 @@
 #define VIF_TYPE_VLAN               6
 #define VIF_TYPE_MAX                7
 
+#define vif_is_fabric(vif)          ((vif->vif_type == VIF_TYPE_PHYSICAL) ||\
+                                        (vif->vif_type == VIF_TYPE_VLAN))
+
 #define vif_is_tap(vif)             ((vif->vif_type == VIF_TYPE_VIRTUAL) ||\
                                         (vif->vif_type == VIF_TYPE_AGENT))
+
 #define vif_is_vhost(vif)           ((vif->vif_type == VIF_TYPE_HOST) ||\
                                         (vif->vif_type == VIF_TYPE_XEN_LL_HOST) ||\
                                         (vif->vif_type == VIF_TYPE_GATEWAY))

--- a/include/vr_mpls.h
+++ b/include/vr_mpls.h
@@ -27,6 +27,7 @@ extern int vr_mpls_dump(vr_mpls_req *);
 extern int vr_mpls_get(vr_mpls_req *);
 extern int vr_mpls_add(vr_mpls_req *);
 extern int vr_mpls_tunnel_type(unsigned int , unsigned int, unsigned short *);
+extern struct vr_nexthop *__vrouter_get_label(struct vrouter *, unsigned int);
 
 
 static inline bool 

--- a/include/vr_packet.h
+++ b/include/vr_packet.h
@@ -202,6 +202,8 @@ struct vr_packet_node {
     unsigned short pl_proto;
     struct vr_packet *pl_packet;
     uint32_t pl_outer_src_ip;
+    uint32_t pl_label;
+    uint32_t pl_vif_idx;
 };
 
 extern void pkt_reset(struct vr_packet *);

--- a/linux/vrouter_mod.c
+++ b/linux/vrouter_mod.c
@@ -344,7 +344,9 @@ lh_work(struct work_struct *work)
 {
     struct work_arg *wa = container_of(work, struct work_arg, wa_work);
 
+    rcu_read_lock();
     wa->fn(wa->wa_arg);
+    rcu_read_unlock();
     kfree(wa);
 
     return;


### PR DESCRIPTION
...y,

do not cache the nexthop in the packet, since a cached nexthop need not be valid
when the packet gets flushed subsequently. Nexthop caching for packets which were
held in flow entry was introduced as part of ECMP support, since a route lookup
will not return the same nexthop as the one from MPLS table. This issue has
now been solved by doing a relookup in the MPLS table for packets that are
held. Also, similar problem can happen for interface pointer cached in the
packet. Fix that behavior too by doing a relook in the interface table and
comparing pointers. While it could so happen that the old interface was deleted,
and the new interface gets the same memory, this check is the best we could do
for sanity.
