### PR TITLE
rejecting the L2 nexthop with non zero rewrite len

### DIFF
--- a/dp-core/vr_nexthop.c
+++ b/dp-core/vr_nexthop.c
@@ -1701,8 +1701,10 @@ nh_encap_add(struct vr_nexthop *nh, vr_nexthop_req *req)
     old_vif = nh->nh_dev;
 
     if (req->nhr_flags & NH_FLAG_ENCAP_L2) {
-         if (req->nhr_encap_size)
+         if (req->nhr_encap_size) {
+             vrouter_put_interface(vif);
              return -EINVAL;
+         }
         nh->nh_dev = vif;
         nh->nh_reach_nh = nh_encap_l2;
     } else {


### PR DESCRIPTION
The L2 nexthop (either unicast or multicast) does not require any encap length. Previously were were accepting the nexthop with rewritelen while adding for the first time. While modifying the nexthop we were rejecting the update as rewrite len given Agent does not match with Kernel's rewrite len. 
Not it is modified to not accept L2 with any rewrite len. 
-Divakar
