### PR TITLE
    Fix the following issues.

### DIFF
--- a/dp-core/vr_interface.c
+++ b/dp-core/vr_interface.c
@@ -307,6 +307,10 @@ agent_rx(struct vr_interface *vif, struct vr_packet *pkt,
             return 0;
         }
 
+        pkt->vp_type = VP_TYPE_AGENT;
+        pkt_set_network_header(pkt, pkt->vp_data + sizeof(struct vr_eth));
+        pkt_set_inner_network_header(pkt, 
+                                     pkt->vp_data + sizeof(struct vr_eth));
         return vif->vif_tx(vif, pkt);
     }
 

--- a/include/vr_packet.h
+++ b/include/vr_packet.h
@@ -63,7 +63,8 @@
 #define VP_TYPE_L2              4
 #define VP_TYPE_L2OIP           5
 #define VP_TYPE_VXLAN           6
-#define VP_TYPE_MAX             7
+#define VP_TYPE_AGENT           7
+#define VP_TYPE_MAX             8 
 
 /*
  * Values to define how to proceed with handling a packet.


### PR DESCRIPTION
```
- ICMP packets larger than the MTU were getting dropped by vrouter. Fix it
by handling fragments correctly.
- With vlan acceleration enabled, ARP packets from the agent were getting
dropped. Fix it by setting the skb network header in vrouter for these
packets.
- Checksum offload was broken for NICs which sent skb with
CHECKSUM_COMPLETE set. Handle these in vrouter.
- In some cases (ingress packet is MPLS instead of IP), MX can send a
GRE tunneled packet with the outer header length set to a larger value
than the sum of the inner header length + tunnel header sizes. Fix it by
verifying checksum using the inner header instead of the outer header in
vrouter.
```
