### PR TITLE
- Ensure that software interrupt is triggered immediately after NAPI cal...

### DIFF
--- a/linux/vr_host_interface.c
+++ b/linux/vr_host_interface.c
@@ -515,6 +515,7 @@ linux_enqueue_pkt_for_gro(struct sk_buff *skb, struct vr_interface *vif)
 {
     struct vr_interface *gro_vif;
     struct vr_interface_stats *gro_vif_stats;
+    int in_intr_context;
 
 #ifdef CONFIG_RPS
     u16 rxq;
@@ -588,7 +589,23 @@ linux_enqueue_pkt_for_gro(struct sk_buff *skb, struct vr_interface *vif)
     
 
     skb_queue_tail(&vif->vr_skb_inputq, skb);
+
+    /*
+     * napi_schedule may raise a softirq, so if we are not already in
+     * interrupt context (which is the case when we get here as a result of
+     * the agent enabling a flow for forwarding), ensure that the softirq is
+     * handled immediately.
+     */
+    in_intr_context = in_interrupt();
+    if (!in_intr_context) {
+        local_bh_disable();
+    }
+
     napi_schedule(&vif->vr_napi);
+
+    if (!in_intr_context) {
+        local_bh_enable();
+    }
 
     return;
 }
@@ -1434,7 +1451,7 @@ linux_pkt_dev_init(char *name, void (*setup)(struct net_device *),
     struct net_device *pdev = NULL;
 
     if (!(pdev = alloc_netdev_mqs(0, name, setup,
-                                  1, num_possible_cpus()))) {
+                                  1, num_present_cpus()))) {
         vr_module_error(-ENOMEM, __FUNCTION__, __LINE__, 0);
         return NULL;
     }


### PR DESCRIPTION
...l on

the GRO interface when the call is initiated as a result of the agent
enabling a flow for forwarding.
- num_possible_cpus() can return more CPUs than are present. Use
  num_present_cpus() instead.
