### PR TITLE
DKMS changes

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -69,7 +69,7 @@ if sys.platform != 'darwin':
                 env['TOP'] + '/tools/sandesh/library/c/' + src))
 
     if GetOption('clean'):
-        os.system('cd ' + dp_dir + '; make clean')
+        os.system('cd ' + dp_dir + ';' + make_cmd + ' clean')
 
     libmod_dir = GetOption('install_root')
     if libmod_dir == None:


### PR DESCRIPTION
With a source package, the aim will be to call a simple make in the module source root to make sure that the module compiles. To accommodate differences in the source tree (and hence the path to sources) between what is present in the repository and what will be present in the distributed package, add variables whose values will be set by the sconscript when in the repository and carries defaults that reflects the standalone source tree.
