### PR TITLE
* If forwarding meta data is not set or if ecmp index is set to -1

### DIFF
--- a/dp-core/vr_nexthop.c
+++ b/dp-core/vr_nexthop.c
@@ -347,7 +347,7 @@ nh_composite_ecmp(unsigned short vrf, struct vr_packet *pkt,
     if (stats)
         stats->vrf_ecmp_composites++;
 
-    if (!fmd || (uint8_t)fmd->fmd_ecmp_nh_index >= nh->nh_component_cnt)
+    if (!fmd || fmd->fmd_ecmp_nh_index >= (short)nh->nh_component_cnt)
         goto drop;
 
     if (fmd->fmd_ecmp_nh_index >= 0)


### PR DESCRIPTION
  trap the packet to vrouter agent for resolving ecmp index
