### PR TITLE
- Address review comments

### DIFF
--- a/dp-core/vr_btable.c
+++ b/dp-core/vr_btable.c
@@ -105,7 +105,14 @@ vr_btable_alloc(unsigned int num_entries, unsigned int entry_size)
     num_parts = total_mem / VR_SINGLE_ALLOC_LIMIT;
     remainder = total_mem % VR_SINGLE_ALLOC_LIMIT;
 
-    total_parts = num_parts + !!remainder;
+    total_parts = num_parts;
+    /*
+     * anything left over that is not a multiple of VR_SINGLE_ALLOC_LIMIT
+     * gets accomodated in the remainder, and hence an extra partition has
+     * to be given
+     */
+    if (remainder)
+        total_parts++;
 
     if (num_parts) {
         /*

--- a/dp-core/vr_flow.c
+++ b/dp-core/vr_flow.c
@@ -1280,7 +1280,7 @@ vr_flow_table_init(struct vrouter *router)
                 sizeof(struct vr_flow_entry));
         if (!router->vr_flow_table) {
             return vr_module_error(-ENOMEM, __FUNCTION__,
-                    __LINE__, VR_DEF_FLOW_ENTRIES);
+                    __LINE__, vr_flow_entries);
         }
     }
 
@@ -1289,7 +1289,7 @@ vr_flow_table_init(struct vrouter *router)
                 sizeof(struct vr_flow_entry));
         if (!router->vr_oflow_table) {
             return vr_module_error(-ENOMEM, __FUNCTION__,
-                    __LINE__, VR_DEF_OFLOW_ENTRIES);
+                    __LINE__, vr_oflow_entries);
         }
     }
 


### PR DESCRIPTION
- Fix message to display the correct number of flow entries when a module
  load fails. This will be different from the default when the flow entries
  are passed as module load argument
