### PR TITLE
- netdev_features_t is only available in 3.3 and later kernels. Fix

### DIFF
--- a/include/vr_compat.h
+++ b/include/vr_compat.h
@@ -7,7 +7,7 @@
 #ifndef __VRCOMPAT_H__
 #define __VRCOMPAT_H__
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,2,54))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0))
 typedef u64 netdev_features_t;
 #endif
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,32))

--- a/linux/vr_host_interface.c
+++ b/linux/vr_host_interface.c
@@ -1466,7 +1466,7 @@ linux_pkt_dev_init(char *name, void (*setup)(struct net_device *),
     struct net_device *pdev = NULL;
 
     if (!(pdev = alloc_netdev_mqs(0, name, setup,
-                                  1, num_possible_cpus()))) {
+                                  1, num_present_cpus()))) {
         vr_module_error(-ENOMEM, __FUNCTION__, __LINE__, 0);
         return NULL;
     }


### PR DESCRIPTION
vr_compat.h to account for this.
- num_possible_cpus() can return more CPUs than are present. Use
  num_present_cpus() instead.
