### PR TITLE
Fix compile error because of changing a name of the skb related function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ SANDESH_LIB_BINS += $(SANDESH_SRC_ROOT)sandesh/library/c/transport/thrift_transp
 SANDESH_LIB_BINS += $(SANDESH_SRC_ROOT)sandesh/library/c/transport/thrift_memory_buffer.o
 SANDESH_LIB_BINS += $(SANDESH_SRC_ROOT)sandesh/library/c/transport/thrift_fake_transport.o
 
+OS_LSB_ID = $(shell awk '{ print $$1; exit }' /etc/issue)
+
 ifneq ($(KERNELRELEASE), )
 	obj-m := vrouter.o
 
@@ -71,6 +73,7 @@ ifneq ($(KERNELRELEASE), )
 	ccflags-y += -I$(src)/include -I$(SANDESH_HEADER_PATH)/sandesh/gen-c
 	ccflags-y += -I$(SANDESH_EXTRA_HEADER_PATH)
 	ccflags-y += -I$(SANDESH_EXTRA_HEADER_PATH)/sandesh/library/c
+	ccflags-y += -DOS_LSB_${OS_LSB_ID}
 	ccflags-y += -g -Wall
 
 	ifeq ($(shell uname -r | grep 2.6.32|grep -c openstack),1)

--- a/include/vr_compat.h
+++ b/include/vr_compat.h
@@ -10,6 +10,13 @@
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0))
 typedef u64 netdev_features_t;
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+#define skb_get_rxhash skb_get_hash
+#elif ((LINUX_VERSION_CODE < KERNEL_VERSION(3,14,0)) && \
+       (LINUX_VERSION_CODE >= KERNEL_VERSION(3,13,0)) && \
+       defined(OS_LSB_Ubuntu))
+#define skb_get_rxhash skb_get_hash
+#endif
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,32))
 static inline __u32
 skb_get_rxhash(struct sk_buff *skb)


### PR DESCRIPTION
From kernel version 3.14.0 and above, skb_get_rxhash() is renamed
to skb_get_hash(). This patch fixes the compile error.

This patch contains a little ugly workaround for Ubuntu 14.04.
Another fix is welcome.
