### PR TITLE
Make vrouter compile on Ubuntu Trusty and Linux 3.14+

### DIFF
--- a/include/vr_compat.h
+++ b/include/vr_compat.h
@@ -13,6 +13,10 @@
 typedef u64 netdev_features_t;
 #endif
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)) || \
+    (defined(UTS_UBUNTU_RELEASE_ABI) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,13,0))
+#define skb_get_rxhash skb_get_hash
+#endif
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,32))
 static inline __u32
 skb_get_rxhash(struct sk_buff *skb)

--- a/linux/vr_host_interface.c
+++ b/linux/vr_host_interface.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
 #include <linux/init.h>
+#include <generated/utsrelease.h>
 #include <linux/version.h>
 #include <linux/kernel.h>
 #include <linux/module.h>


### PR DESCRIPTION
Ubuntu cherry-picked an API breaking change from 3.14 into their 3.13 tree, hence the "interesting" #ifdefs
